### PR TITLE
Update InfiniteFlightConnectOld.py

### DIFF
--- a/InfiniteFlightConnectOld.py
+++ b/InfiniteFlightConnectOld.py
@@ -1,5 +1,6 @@
 import socket
 import json
+import struct
 from binascii import unhexlify
 
 udp = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -27,9 +28,8 @@ def send_command(cmd, params, await_response=False):
     tcp.sendall(request)
     if await_response:
         print(f"{ADDR} [AWAITING RESPONSE from {IP} : {PORT}] Request has been sent to Infinite Flight")
-        response_length = tcp.recv(4).hex().strip("00")
-        response_length = "".join(reversed([response_length[i:i+2] for i in range(0, len(response_length), 2)]))
-        response_length = int(response_length, 16)
+        response_length = tcp.recv(4)[:2]
+        response_length = struct.unpack('<H', response_length)[0]
         response = tcp.recv(response_length).decode("utf-8")
         print(f'{ADDR} [RESPONSE RECIEVED from {IP} : {PORT}]')
         return response


### PR DESCRIPTION
Bugfix: when receive\x24\x10\x00\x00, tcp.recv(4).hex().strip('00') will get '241' instead of '2410'